### PR TITLE
Going back to v1 compatibility

### DIFF
--- a/config.js
+++ b/config.js
@@ -17,7 +17,7 @@ module.exports = {
   middleware: {
     limiter: {
       //max requests/minutes per IP address.
-      //rejected POST's count towards this limit (so if ie. the antispam middleware blocks the request, it still counts towards their limit)
+      //rejected POST's count towards this limit
       minutes: 30,
       maxRequests: 10,
     },
@@ -25,10 +25,10 @@ module.exports = {
       // allowed host request header values used by verifyHost middleware
       'https://waxshop.ca',
       'https://dev.waxshop.ca',
-      // 'localhost:8080' // for dev/testing
+      //'http://localhost:8080' // for dev/testing
     ],
     requiredBodyFields: [
-      // the post request body must be an object that has the following properties
+      // the post request body must be a JSON object that has the following properties
       'name',
       'email',
       'text'

--- a/config.js
+++ b/config.js
@@ -11,6 +11,7 @@ module.exports = {
   mail: {
     to: secrets.to,
     from: secrets.user,
+    cc: secrets.cc,
     subject: 'Website contact from:'// + name
   },
   middleware: {

--- a/config.js
+++ b/config.js
@@ -20,11 +20,11 @@ module.exports = {
       minutes: 30,
       maxRequests: 10,
     },
-    validHosts: [
+    validReferers: [
       // allowed host request header values used by verifyHost middleware
-      'waxshop.ca',
-      'dev.waxshop.ca',
-      // 'localhost:8080'
+      'https://waxshop.ca',
+      'https://dev.waxshop.ca',
+      // 'localhost:8080' // for dev/testing
     ],
     requiredBodyFields: [
       // the post request body must be an object that has the following properties

--- a/generate_secrets_js.sh
+++ b/generate_secrets_js.sh
@@ -6,7 +6,8 @@ if [ ! -f secrets.js ]; then
     echo "module.exports = {
     user: 'username@domain.com',
     pass: 'your_pass_here',
-    to: 'target@domain.com'
+    to: 'target@domain.com',
+    cc: 'cc@domain.com,cc2@domain.com'
 };" > secrets.js
     echo "Done!"
     exit 0

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,0 +1,32 @@
+const Memcached = require('memcached');
+const memcached = new Memcached('127.0.0.1:11211', { maxExpiration: 3600 });
+
+module.exports = {
+  addKey: (k, v) => new Promise((resolve, reject) =>{
+    memcached.add(k, v, 1800, (err, result) => {
+      if (err || !result) {
+        reject(err || result)
+      } else {
+        resolve(true)
+      }
+    })
+  }),
+  getKey: (k) => new Promise((resolve, reject) =>{
+    memcached.get(k, (err, data) => {
+      if (err || !data) {
+        reject(err)
+      } else {
+        resolve(data)
+      }
+    })
+  }),
+  deleteKey: (k) => new Promise((resolve, reject) =>{
+    memcached.del(k, (err, result) => {
+      if (err || !result) {
+        reject(err || result)
+      } else {
+        resolve(true)
+      }
+    })
+  })
+};

--- a/lib/controllers.js
+++ b/lib/controllers.js
@@ -25,10 +25,20 @@ module.exports = {
           // so eg. malicious links, tracking pixels won't be effective.
       };
       transporter.sendMail(mailOptions,  (err, info) => {
-          if (err || info.rejected.length) {
-              next( utils.buildError('sendmail') )
+          if (
+            err ||
+            (
+              info.rejected.length
+              // nodemailer-mock returns both, so this prevents failure during dev/testing
+              && (process.env.NODE_ENV === 'production' || !info.accepted.length)
+            )
+          ) {
+              next( utils.buildError('sendmail') );
           } else {
-              res.json({success: true});
+              res.json({
+                success: true,
+                message: process.env.NODE_ENV === 'production' ? 'Message sent' : info.response
+              });
           }
       })
     },

--- a/lib/controllers.js
+++ b/lib/controllers.js
@@ -1,5 +1,8 @@
+const { v4: uuidv4 } = require('uuid');
+
 const config = require('../config.js');
 const utils = require('./utils.js');
+const cache = require('./cache.js');
 
 module.exports = {
   sendMail: (transporter) => 
@@ -27,6 +30,19 @@ module.exports = {
               res.json({success: true});
           }
       })
-    }
+    },
   
-}
+  getToken: async (req, res, next) => {
+    const token = uuidv4();
+    const now = Date.now();
+    const metadata = { issued: now, expires: now + (3600*1000) };
+    try {
+      await cache.addKey(token, JSON.stringify(metadata));
+      res.json({ success: true, token: token, expires: metadata.expires });
+    } catch (error) {
+      // addKey failed, likely because the key already exists. This should not be possible.
+      next( utils.buildError('token-collision') )
+    }
+  }
+
+};

--- a/lib/controllers.js
+++ b/lib/controllers.js
@@ -14,6 +14,7 @@ module.exports = {
       };
       const mailOptions = {
           to: config.mail.to,
+          cc: config.mail.cc,
           subject: `${config.mail.subject} ${contactMsg.name}`,
           from: config.mail.from,
           replyTo: contactMsg.email,

--- a/lib/controllers.js
+++ b/lib/controllers.js
@@ -1,8 +1,8 @@
-const { v4: uuidv4 } = require('uuid');
+// const { v4: uuidv4 } = require('uuid'); // disabled for now
 
 const config = require('../config.js');
 const utils = require('./utils.js');
-const cache = require('./cache.js');
+// const cache = require('./cache.js'); // disabled for now
 
 module.exports = {
   sendMail: (transporter) => 
@@ -32,18 +32,18 @@ module.exports = {
           }
       })
     },
-  
-  getToken: async (req, res, next) => {
-    const token = uuidv4();
-    const now = Date.now();
-    const metadata = { issued: now, expires: now + (3600*1000) };
-    try {
-      await cache.addKey(token, JSON.stringify(metadata));
-      res.json({ success: true, token: token, expires: metadata.expires });
-    } catch (error) {
-      // addKey failed, likely because the key already exists. This should not be possible.
-      next( utils.buildError('token-collision') )
-    }
-  }
+  // disabled for now - i think this works though :D
+  // getToken: async (req, res, next) => {
+  //   const token = uuidv4();
+  //   const now = Date.now();
+  //   const metadata = { issued: now, expires: now + (3600*1000) };
+  //   try {
+  //     await cache.addKey(token, JSON.stringify(metadata));
+  //     res.json({ success: true, token: token, expires: metadata.expires });
+  //   } catch (error) {
+  //     // addKey failed, likely because the key already exists. This should not be possible.
+  //     next( utils.buildError('token-collision') )
+  //   }
+  // }
 
 };

--- a/lib/createTransport.js
+++ b/lib/createTransport.js
@@ -1,4 +1,5 @@
-const nodemailer = require("nodemailer");
+const nodemailerOrMock = (process.env.NODE_ENV === "production") ? "nodemailer" : "nodemailer-mock";
+const nodemailer = require(nodemailerOrMock);
 const errorHandler = require("./errorHandler.js");
 const config = require("../config.js");
 

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -3,6 +3,8 @@ const rateLimit = require('express-rate-limit');
 const utils = require('../lib/utils.js');
 const config = require('../config.js');
 const errorHandler = require('../lib/errorHandler.js');
+const cache = require('./cache.js');
+const tokenObjectKeys = ['issued', 'expires'];
 
 const notEmptyOrWhitespace = (str) => (typeof str === "string" && str.trim()) ? true : false;
 // returns true if str is a string & is not 0-length or all whitespace
@@ -38,14 +40,41 @@ module.exports = {
     }
   },
 
-  verifyHost: (req, res, next) => {
-    const validHosts = config.middleware.validHosts;
-    const hostHeader = req.headers.host;
-    const valid = validHosts.some(host => host === hostHeader);
+  verifyReferer: (req, res, next) => {
+
+    const validReferers = config.middleware.validReferers;
+    const refererHeader = req.headers.referer;
+    const valid = validReferers.some(referer => referer === refererHeader);
     if (valid) {
       next()
     } else {
       next(utils.buildError('invalid-referer'))
+    }
+  },
+
+  verifyToken: async (req, res, next) => {
+    try {
+      const token = req.body.token || '';
+      // will reject if key not found/expired
+      const tokenObject = JSON.parse(await cache.getKey(token));
+      // verify that the object has the required properties
+      const tokenKeysValid = tokenObjectKeys.every(key => tokenObject.hasOwnProperty(key));
+      // the value passed to next()
+      let nextParam = undefined;
+      if (tokenKeysValid) {
+        const { issued, expires } = tokenObject;
+        const now = Date.now();
+        const isValid = issued < now && expires > now;
+        if (!isValid) {
+          nextParam = utils.buildError('invalid-token');
+        }
+      } else {
+        nextParam = utils.buildError('invalid-token');
+      }
+      next(nextParam);
+    } catch (error) {
+      console.log();
+      next(utils.buildError('invalid-token'));
     }
   }
 

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -3,8 +3,8 @@ const rateLimit = require('express-rate-limit');
 const utils = require('../lib/utils.js');
 const config = require('../config.js');
 const errorHandler = require('../lib/errorHandler.js');
-const cache = require('./cache.js');
-const tokenObjectKeys = ['issued', 'expires'];
+// const cache = require('./cache.js'); // disabled for now
+// const tokenObjectKeys = ['issued', 'expires']; // disabled for now
 
 const notEmptyOrWhitespace = (str) => (typeof str === "string" && str.trim()) ? true : false;
 // returns true if str is a string & is not 0-length or all whitespace
@@ -52,30 +52,30 @@ module.exports = {
     }
   },
 
-  verifyToken: async (req, res, next) => {
-    try {
-      const token = req.body.token || '';
-      // will reject if key not found/expired
-      const tokenObject = JSON.parse(await cache.getKey(token));
-      // verify that the object has the required properties
-      const tokenKeysValid = tokenObjectKeys.every(key => tokenObject.hasOwnProperty(key));
-      // the value passed to next()
-      let nextParam = undefined;
-      if (tokenKeysValid) {
-        const { issued, expires } = tokenObject;
-        const now = Date.now();
-        const isValid = issued < now && expires > now;
-        if (!isValid) {
-          nextParam = utils.buildError('invalid-token');
-        }
-      } else {
-        nextParam = utils.buildError('invalid-token');
-      }
-      next(nextParam);
-    } catch (error) {
-      console.log();
-      next(utils.buildError('invalid-token'));
-    }
-  }
+  // verifyToken: async (req, res, next) => { // disabled for now
+  //   try {
+  //     const token = req.body.token || '';
+  //     // will reject if key not found/expired
+  //     const tokenObject = JSON.parse(await cache.getKey(token));
+  //     // verify that the object has the required properties
+  //     const tokenKeysValid = tokenObjectKeys.every(key => tokenObject.hasOwnProperty(key));
+  //     // the value passed to next()
+  //     let nextParam = undefined;
+  //     if (tokenKeysValid) {
+  //       const { issued, expires } = tokenObject;
+  //       const now = Date.now();
+  //       const isValid = issued < now && expires > now;
+  //       if (!isValid) {
+  //         nextParam = utils.buildError('invalid-token');
+  //       }
+  //     } else {
+  //       nextParam = utils.buildError('invalid-token');
+  //     }
+  //     next(nextParam);
+  //   } catch (error) {
+  //     console.log();
+  //     next(utils.buildError('invalid-token'));
+  //   }
+  // }
 
 };

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -44,7 +44,7 @@ module.exports = {
 
     const validReferers = config.middleware.validReferers;
     const refererHeader = req.headers.referer;
-    const valid = validReferers.some(referer => referer === refererHeader);
+    const valid = validReferers.some(referer => refererHeader.startsWith(referer));
     if (valid) {
       next()
     } else {

--- a/lib/router.js
+++ b/lib/router.js
@@ -1,18 +1,38 @@
-const middleware = require('./middleware.js');
-const utils = require('./utils.js');
+const {
+  limiter,
+  verifyReferer,
+  verifyContentType,
+  verifyContactMsgObj,
+  verifyToken,
+} = require("./middleware.js");
+const utils = require("./utils.js");
+const { getToken } = require("./controllers.js");
+// const { verifyToken } = require("./services.js");
+
+const notFoundHandler = (req, res, next) => {
+  next(utils.buildError("not-found"));
+};
 
 const createRouter = (express, sendMail) => {
   const router = express.Router();
-  router.use(middleware.limiter);
-  router.use(middleware.verifyHost);
-  router.use(middleware.verifyContentType);
-  router.use(middleware.verifyContactMsgObj);
-  router.post('/send', sendMail);
-  router.use( (req,res,next) => {
-    // returns 404 when no routes match. enables sending a json 404 response
-    next( utils.buildError('not-found') )
+  // general middleware
+  router.use(limiter);
+  router.use(verifyReferer);
+  // router.use(verifyContentType);
+  // /send endpoint
+  router.use("/send", verifyContentType);
+  router.use("/send", verifyContactMsgObj);
+  router.use("/send", verifyToken);
+  router.post("/send", sendMail);
+  // /token endpoint
+  router.post("/token", getToken);
+  router.post("/verify", verifyToken, async (req, res) => {
+    // const valid = await verifyToken(req.body.token);
+    res.json({ valid:true });
   });
+  // enables sending a json 404 response
+  router.use(notFoundHandler);
   return router;
-}
+};
 
 module.exports = createRouter;

--- a/lib/router.js
+++ b/lib/router.js
@@ -3,11 +3,10 @@ const {
   verifyReferer,
   verifyContentType,
   verifyContactMsgObj,
-  verifyToken,
+  // verifyToken, // disabled for now
 } = require("./middleware.js");
 const utils = require("./utils.js");
-const { getToken } = require("./controllers.js");
-// const { verifyToken } = require("./services.js");
+// const { getToken } = require("./controllers.js"); // disabled for now
 
 const notFoundHandler = (req, res, next) => {
   next(utils.buildError("not-found"));
@@ -22,14 +21,14 @@ const createRouter = (express, sendMail) => {
   // /send endpoint
   router.use("/send", verifyContentType);
   router.use("/send", verifyContactMsgObj);
-  router.use("/send", verifyToken);
+  // router.use("/send", verifyToken); // disabled for now
   router.post("/send", sendMail);
-  // /token endpoint
-  router.post("/token", getToken);
-  router.post("/verify", verifyToken, async (req, res) => {
+  // /token endpoint - partial impl. disabled for now.
+  // router.post("/token", getToken);
+  // router.post("/verify", verifyToken, async (req, res) => {
     // const valid = await verifyToken(req.body.token);
-    res.json({ valid:true });
-  });
+    // res.json({ valid:true });
+  // });
   // enables sending a json 404 response
   router.use(notFoundHandler);
   return router;

--- a/lib/services.js
+++ b/lib/services.js
@@ -1,0 +1,23 @@
+const cache = require("./cache.js");
+
+const verifyToken = async (token) => {
+  let result = false;
+  try {
+    const metadata = await cache.getKey(token);
+    const now = Date.now();
+    if (
+      metadata &&
+      metadata.issued &&
+      metadata.expires &&
+      now > metadata.issued &&
+      now < metadata.expires
+    ) {
+      result = true;
+    }
+  } catch (error) {
+    //
+  }
+  return result;
+};
+
+module.exports = { verifyToken };

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,11 @@
             "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
             "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
         },
+        "connection-parse": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/connection-parse/-/connection-parse-0.0.7.tgz",
+            "integrity": "sha1-GOcxiqsGppkmc3KxDFIm0locmmk="
+        },
         "content-disposition": {
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
@@ -254,6 +259,15 @@
             "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
             "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
         },
+        "hashring": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/hashring/-/hashring-3.2.0.tgz",
+            "integrity": "sha1-/aTv3oqiLNuX+x0qZeiEAeHBRM4=",
+            "requires": {
+                "connection-parse": "0.0.x",
+                "simple-lru-cache": "0.0.x"
+            }
+        },
         "http-errors": {
             "version": "1.6.3",
             "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
@@ -283,10 +297,27 @@
             "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
             "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
         },
+        "jackpot": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/jackpot/-/jackpot-0.0.6.tgz",
+            "integrity": "sha1-PP8GQoXL9m9OqyWTyQvOgWqCGEk=",
+            "requires": {
+                "retry": "0.6.0"
+            }
+        },
         "media-typer": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
             "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+        },
+        "memcached": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/memcached/-/memcached-2.2.2.tgz",
+            "integrity": "sha1-aPhsz9hLz5PMJe1G1tf8DHUhydU=",
+            "requires": {
+                "hashring": "3.2.x",
+                "jackpot": ">=0.0.6"
+            }
         },
         "merge-descriptors": {
             "version": "1.0.1",
@@ -330,6 +361,39 @@
             "version": "4.6.8",
             "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-4.6.8.tgz",
             "integrity": "sha512-A3s7EM/426OBIZbLHXq2KkgvmKbn2Xga4m4G+ZUA4IaZvG8PcZXrFh+2E4VaS2o+emhuUVRnzKN2YmpkXQ9qwA=="
+        },
+        "nodemailer-mock": {
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/nodemailer-mock/-/nodemailer-mock-1.5.3.tgz",
+            "integrity": "sha512-Y0JYLFjx+HMNB1Y55uYj+6Vk7ZkJyMKH6GY85UgaSsaaWdH7BE7j0pH7Tp8H4qvQkWSycDh/76iWlHb4dEiWtg==",
+            "dev": true,
+            "requires": {
+                "debug": "4.1.1",
+                "nodemailer": "6.x"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "nodemailer": {
+                    "version": "6.4.11",
+                    "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.4.11.tgz",
+                    "integrity": "sha512-BVZBDi+aJV4O38rxsUh164Dk1NCqgh6Cm0rQSb9SK/DHGll/DrCMnycVDD7msJgZCnmVa8ASo8EZzR7jsgTukQ==",
+                    "dev": true
+                }
+            }
         },
         "object-assign": {
             "version": "4.1.1",
@@ -384,6 +448,11 @@
                 "unpipe": "1.0.0"
             }
         },
+        "retry": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz",
+            "integrity": "sha1-HAEHEyeab9Ho3vKK8MP/GHHKpTc="
+        },
         "safe-buffer": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
@@ -430,6 +499,11 @@
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
             "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
         },
+        "simple-lru-cache": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz",
+            "integrity": "sha1-1ZzDoZPBpdAyD4Tucy9uRxPlEd0="
+        },
         "statuses": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
@@ -453,6 +527,11 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
             "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+        },
+        "uuid": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
+            "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ=="
         },
         "vary": {
             "version": "1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,11 +52,6 @@
             "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
             "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
         },
-        "connection-parse": {
-            "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/connection-parse/-/connection-parse-0.0.7.tgz",
-            "integrity": "sha1-GOcxiqsGppkmc3KxDFIm0locmmk="
-        },
         "content-disposition": {
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
@@ -259,15 +254,6 @@
             "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
             "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
         },
-        "hashring": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/hashring/-/hashring-3.2.0.tgz",
-            "integrity": "sha1-/aTv3oqiLNuX+x0qZeiEAeHBRM4=",
-            "requires": {
-                "connection-parse": "0.0.x",
-                "simple-lru-cache": "0.0.x"
-            }
-        },
         "http-errors": {
             "version": "1.6.3",
             "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
@@ -297,27 +283,10 @@
             "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
             "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
         },
-        "jackpot": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/jackpot/-/jackpot-0.0.6.tgz",
-            "integrity": "sha1-PP8GQoXL9m9OqyWTyQvOgWqCGEk=",
-            "requires": {
-                "retry": "0.6.0"
-            }
-        },
         "media-typer": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
             "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
-        },
-        "memcached": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/memcached/-/memcached-2.2.2.tgz",
-            "integrity": "sha1-aPhsz9hLz5PMJe1G1tf8DHUhydU=",
-            "requires": {
-                "hashring": "3.2.x",
-                "jackpot": ">=0.0.6"
-            }
         },
         "merge-descriptors": {
             "version": "1.0.1",
@@ -448,11 +417,6 @@
                 "unpipe": "1.0.0"
             }
         },
-        "retry": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz",
-            "integrity": "sha1-HAEHEyeab9Ho3vKK8MP/GHHKpTc="
-        },
         "safe-buffer": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
@@ -498,11 +462,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
             "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
-        },
-        "simple-lru-cache": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz",
-            "integrity": "sha1-1ZzDoZPBpdAyD4Tucy9uRxPlEd0="
         },
         "statuses": {
             "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
         "cors": "^2.8.5",
         "express": "^4.16.3",
         "express-rate-limit": "^3.1.1",
-        "memcached": "^2.2.2",
         "nodemailer": "^4.6.8",
         "uuid": "^8.3.0"
     },

--- a/package.json
+++ b/package.json
@@ -21,6 +21,11 @@
         "cors": "^2.8.5",
         "express": "^4.16.3",
         "express-rate-limit": "^3.1.1",
-        "nodemailer": "^4.6.8"
+        "memcached": "^2.2.2",
+        "nodemailer": "^4.6.8",
+        "uuid": "^8.3.0"
+    },
+    "devDependencies": {
+        "nodemailer-mock": "^1.5.3"
     }
 }

--- a/readme.MD
+++ b/readme.MD
@@ -20,9 +20,7 @@ Validates and sanitizes user supplied information. Secure defaults like binding 
 
 Gracefully handles operational errors.
 
-Bot-resistant***: Generic spam bots shouldnt succeed at sending email.
-
-Configurable rate-limiting by IP in case abuse gets through.
+Configurable rate-limiting by IP.
 
 Run as a system service in production. Logging, monitoring, etc.
 

--- a/server.js
+++ b/server.js
@@ -29,7 +29,7 @@ const main = async () => {
   const sendMail = require("./lib/controllers.js").sendMail(transporter);
   const router = require("./lib/router.js")(express, sendMail);
 
-  app.use("/v2", router);
+  app.use("/v1", router);
   app.use(errorHandler.main);
 
   const server = app.listen(config.port, config.host, () => {

--- a/server.js
+++ b/server.js
@@ -29,7 +29,7 @@ const main = async () => {
   const sendMail = require("./lib/controllers.js").sendMail(transporter);
   const router = require("./lib/router.js")(express, sendMail);
 
-  app.use("/v1", router);
+  app.use("/v2", router);
   app.use(errorHandler.main);
 
   const server = app.listen(config.port, config.host, () => {


### PR DESCRIPTION
This work-in-progress  implementation of a v2 was really stale code. I am taking some of the improvements from this branch but going back to compatibility with `v1`. The improvements include supporting mocking for testing and some middleware changes.

The major difference is disabling all code related to CSRF tokens, as that breaks compat and isn't fully implemented yet. I don't want to throw it all out, so I just commented it out to encourage me to deal with it at some point.